### PR TITLE
Fix: re-raise original docker exception in Sandbox.start error handlers

### DIFF
--- a/deadend_cli/deadend_agent/src/deadend_agent/sandbox/sandbox.py
+++ b/deadend_cli/deadend_agent/src/deadend_agent/sandbox/sandbox.py
@@ -197,10 +197,10 @@ class Sandbox(BaseModel):
             return container
         except ImageNotFound as exc:
             logger.error("Image not found %s", container_image)
-            raise ImageNotFound from exc
+            raise exc
         except NotFound as exc:
             logger.error("Docker error: %s", exc.explanation)
-            raise NotFound from exc
+            raise exc
         except Exception as exc:
             self.status = SandboxStatus.ERROR
             logger.error("Error starting container: %s", exc)


### PR DESCRIPTION
Fixes #74

## Summary

`Sandbox.start()` re-raised docker errors by constructing a **new** exception without a message:

```python
except ImageNotFound as exc:
    raise ImageNotFound from exc   # ImageNotFound() → APIError() → TypeError
except NotFound as exc:
    raise NotFound from exc
```

`docker.errors.ImageNotFound`/`NotFound` inherit `APIError`, whose `__init__` requires `message`. The no-arg construction raises `TypeError: APIError.__init__() missing 1 required positional argument: 'message'`, masking the real error — e.g. when `xoxruns/sandboxed_kali` is missing locally, the user sees this TypeError instead of `ImageNotFound`.

## Change

Re-raise the original exception in both handlers:

```python
except ImageNotFound as exc:
    logger.error("Image not found %s", container_image)
    raise exc
except NotFound as exc:
    logger.error("Docker error: %s", exc.explanation)
    raise exc
```

## Verification

- Pre-fix: `TypeError: APIError.__init__() missing 1 required positional argument: 'message'` reproduced with docker SDK 7.1.0 (both with real SDK and the exact class hierarchy).
- Post-fix: the original `docker.errors.ImageNotFound` propagates with its explanation intact.
- Live check: with the sandbox image pulled, the CLI no longer reports the sandbox-creation failure.

Note: full `pytest` suite not run here (dependencies not installed in this environment); the change is limited to the two exception-handler lines and does not alter normal flow.
